### PR TITLE
Bump langchain for n8n 2.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-opensearch",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Adds OpenSearch vector store and generic nodes to n8n",
   "keywords": [
     "n8n-community-node-package"
@@ -44,26 +44,25 @@
     ]
   },
   "dependencies": {
-    "@opensearch-project/opensearch": "2.12.0",
-    "@langchain/community": "0.3.32"
+    "@opensearch-project/opensearch": "^2.12.0",
+    "@langchain/community": "^1.0.5"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.10",
     "@typescript-eslint/parser": "^7.15.0",
-    "@langchain/community": "^0.3.2",
-    "@langchain/core": "^0.3.3",
-    "@langchain/textsplitters": "0.1.0",
+    "@langchain/core": "^1.1.0",
+    "@langchain/textsplitters": "^1.0.1",
     "eslint": "^8.56.0",
     "eslint-plugin-n8n-nodes-base": "^1.16.1",
     "gulp": "^4.0.2",
-    "langchain": "^0.3.2",
+    "langchain": "^1.1.1",
     "lodash": "^4.17.21",
     "prettier": "^3.3.2",
-    "tmp-promise": "3.0.3",
-    "typescript": "^5.5.3",
-    "zod": "3.23.8"
+    "tmp-promise": "^3.0.3",
+    "typescript": "^5.7.2",
+    "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "n8n-workflow": "1.48.0"
+    "n8n-workflow": ">=1.48.0"
   }
 }

--- a/utils/N8nBinaryLoader.ts
+++ b/utils/N8nBinaryLoader.ts
@@ -8,9 +8,9 @@ import type { TextSplitter } from '@langchain/textsplitters';
 import type { Document } from '@langchain/core/documents';
 import { CSVLoader } from '@langchain/community/document_loaders/fs/csv';
 import { DocxLoader } from '@langchain/community/document_loaders/fs/docx';
-import { JSONLoader } from 'langchain/document_loaders/fs/json';
+import { JSONLoader } from '@langchain/community/document_loaders/fs/json';
 import { PDFLoader } from '@langchain/community/document_loaders/fs/pdf';
-import { TextLoader } from 'langchain/document_loaders/fs/text';
+import { TextLoader } from '@langchain/community/document_loaders/fs/text';
 import { EPubLoader } from '@langchain/community/document_loaders/fs/epub';
 import { file as tmpFile, type DirectoryResult } from 'tmp-promise';
 

--- a/utils/N8nJsonLoader.ts
+++ b/utils/N8nJsonLoader.ts
@@ -3,8 +3,8 @@ import { type IExecuteFunctions, type INodeExecutionData, NodeOperationError } f
 
 import type { TextSplitter } from '@langchain/textsplitters';
 import type { Document } from '@langchain/core/documents';
-import { JSONLoader } from 'langchain/document_loaders/fs/json';
-import { TextLoader } from 'langchain/document_loaders/fs/text';
+import { JSONLoader } from '@langchain/community/document_loaders/fs/json';
+import { TextLoader } from '@langchain/community/document_loaders/fs/text';
 import { getMetadataFiltersValues } from './helpers';
 
 export class N8nJsonLoader {


### PR DESCRIPTION
### Changes

#### Fixed LangChain Imports
- Updated deprecated import paths in `utils/N8nJsonLoader.ts` and `utils/N8nBinaryLoader.ts`
- Changed from `langchain/document_loaders/fs/*` to `@langchain/community/document_loaders/fs/*`

#### Updated Dependencies to LangChain 1.x
Aligned with n8n 2.1.0's LangChain versions:
- `@langchain/community`: 0.3.32 → ^1.0.5
- `@langchain/core`: ^0.3.3 → ^1.1.0
- `@langchain/textsplitters`: 0.1.0 → ^1.0.1
- `langchain`: ^0.3.2 → ^1.1.1
- `typescript`: ^5.5.3 → ^5.7.2

#### Other Fixes
- Removed duplicate `@langchain/community` from devDependencies
- Updated `n8n-workflow` peer dependency from `1.48.0` to `>=1.48.0`
- Added caret ranges (`^`) to all dependencies for automatic patch updates
- Bumped package version to 0.1.4
